### PR TITLE
Fix replacement of existing file on re-runing of make repository command

### DIFF
--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -280,16 +280,11 @@ class Generator extends Command
         }
 
         if(is_dir($filePath) && file_exists($content)){
-
             // Ask to replace exiting file
-            if ($this->confirm("This file, {$content} already exit, do you want to replace?")) {
-                file_put_contents($content, $template);
-                $this->line('File Replaced');
-
+            if (! $this->confirm("This file, {$content} already exit, do you want to replace?")) {
+                $this->line('File Not Replaced');
                 return false;
             }
-            $this->line('File Not Replaced');
-            return false;
         }
 
         file_put_contents($content, $template);

--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -83,6 +83,7 @@ class Generator extends Command
 
     public function makeRepositoryPatternFiles($path)
     {
+
         $model = Str::plural(Config::get('repository.model'));
         $interface = Str::plural(Config::get('repository.interface'));
         $repository = Str::plural(Config::get('repository.repository'));
@@ -229,7 +230,7 @@ class Generator extends Command
      */
     public function getFolderOrCreate($path)
     {
-        if (! file_exists($path)) {
+        if (! file_exists($path) && ! is_dir($path)) {
             mkdir($path, 0777, true);
         }
 

--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -74,7 +74,7 @@ class Generator extends Command
 
         if ($this->option('only-view')) {
             $this->makeViewsAndLanguage($path);
-            $this->dumpAutoload();
+
             return true;
         }
 
@@ -83,7 +83,6 @@ class Generator extends Command
 
     public function makeRepositoryPatternFiles($path)
     {
-
         $model = Str::plural(Config::get('repository.model'));
         $interface = Str::plural(Config::get('repository.interface'));
         $repository = Str::plural(Config::get('repository.repository'));
@@ -101,8 +100,6 @@ class Generator extends Command
         $webContent = "\nRoute::resource('{$pluralName}', '{$controllerPath}');";
 
         File::append($webFile, $webContent);
-
-        $this->dumpAutoload();
         return true;
     }
 
@@ -184,6 +181,7 @@ class Generator extends Command
     protected function generate($path, $folder, $type, $form = '')
     {
         $path = $path ? '\\'.$path : '';
+
         $content = $this->getStub($type);
 
         if (false === $content) {
@@ -216,6 +214,7 @@ class Generator extends Command
 
         $folder = str_replace('\\', '/', $folder);
         $path = str_replace('\\', '/', $path);
+
         $this->type($type, $folder, $path, $template);
 
         return true;
@@ -230,7 +229,7 @@ class Generator extends Command
      */
     public function getFolderOrCreate($path)
     {
-        if (! file_exists($path) && ! is_dir($path)) {
+        if (! file_exists($path)) {
             mkdir($path, 0777, true);
         }
 
@@ -275,11 +274,13 @@ class Generator extends Command
                 $repoName = lcfirst($this->repoName);
                 $content = $filePath.$repoName.'.php';
         }
-        file_put_contents($content, $template);
-    }
 
-    function dumpAutoload()
-    {
-        shell_exec('composer dump-autoload');
+        if(is_dir($filePath) && file_exists($content)){
+            $this->info($content . ' File Already Exists');
+
+            return false;
+        }
+
+        file_put_contents($content, $template);
     }
 }

--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -103,6 +103,9 @@ class Generator extends Command
 
         File::put($webFile, $webFileContent);
         File::append($webFile, $webContent);
+
+        $this->dumpAutoload();
+
         return true;
     }
 
@@ -277,8 +280,15 @@ class Generator extends Command
         }
 
         if(is_dir($filePath) && file_exists($content)){
-            $this->info($content . ' File Already Exists');
 
+            // Ask to replace exiting file
+            if ($this->confirm("This file, {$content} already exit, do you want to replace?")) {
+                file_put_contents($content, $template);
+                $this->line('File Replaced');
+
+                return false;
+            }
+            $this->line('File Not Replaced');
             return false;
         }
 

--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -99,6 +99,9 @@ class Generator extends Command
 
         $webContent = "\nRoute::resource('{$pluralName}', '{$controllerPath}');";
 
+        $webFileContent = str_replace($webContent, '', file_get_contents($webFile));
+
+        File::put($webFile, $webFileContent);
         File::append($webFile, $webContent);
         return true;
     }

--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -61,9 +61,9 @@ class Generator extends Command
      */
     public function handle()
     {
-        $file = preg_split(' (/|\\\\) ', (string) $this->argument('name')) ?? [];
+        $file = preg_split(' (/|\\\\) ', (string)$this->argument('name')) ?? [];
 
-        if (! $file) {
+        if (!$file) {
             return 'Something wrong with the inputs !';
         }
 
@@ -74,7 +74,7 @@ class Generator extends Command
 
         if ($this->option('only-view')) {
             $this->makeViewsAndLanguage($path);
-
+            $this->dumpAutoload();
             return true;
         }
 
@@ -93,9 +93,9 @@ class Generator extends Command
         $this->generate($path, $interface, 'Interface');
         $this->generate($path, $repository, 'Repository');
 
-        $webFile = Config::get('repository.route_path').'/web.php';
+        $webFile = Config::get('repository.route_path') . '/web.php';
         $pluralName = strtolower(Str::plural($this->repoName));
-        $controllerPath = $path.'\\'.$this->repoName.'Controller';
+        $controllerPath = $path . '\\' . $this->repoName . 'Controller';
 
         $webContent = "\nRoute::resource('{$pluralName}', '{$controllerPath}');";
 
@@ -123,13 +123,13 @@ class Generator extends Command
         } else {
             $message = "There is no entity for {$this->repoName}, 
                         do you want to continue (this will disable form generator) ?";
-            if (! $this->confirm($message)) {
+            if (!$this->confirm($message)) {
                 echo 'Dispatch ..';
                 die;
             }
         }
         $repositoryName = lcfirst($this->repoName);
-        $viewsPath = Config::get('repository.resources_path').'/views';
+        $viewsPath = Config::get('repository.resources_path') . '/views';
         $languagePath = Config::get('repository.lang_path');
 
         foreach (Config::get('repository.languages') as $lang) {
@@ -145,14 +145,14 @@ class Generator extends Command
     /**
      * @param $path
      *
+     * @return bool|Model|object
      * @throws ReflectionException
      *
-     * @return bool|Model|object
      */
     public function getEntity($path)
     {
-        $myClass = 'App\Entities\\'.$path.'\\'.$this->repoName;
-        if (! class_exists($myClass)) {
+        $myClass = 'App\Entities\\' . $path . '\\' . $this->repoName;
+        if (!class_exists($myClass)) {
             return false;
         }
 
@@ -170,25 +170,24 @@ class Generator extends Command
      */
     protected function getStub($type)
     {
-        return file_get_contents(Config::get('repository.stubs_path')."/$type.stub");
+        return file_get_contents(Config::get('repository.stubs_path') . "/$type.stub");
     }
 
     /**
-     * @param string $path   Class path
+     * @param string $path Class path
      * @param string $folder default path to generate in
-     * @param string $type   define which kind of files should generate
+     * @param string $type define which kind of files should generate
      * @param string $form
      *
      * @return bool
      */
     protected function generate($path, $folder, $type, $form = '')
     {
-        $path = $path ? '\\'.$path : '';
-
+        $path = $path ? '\\' . $path : '';
         $content = $this->getStub($type);
 
         if (false === $content) {
-            echo 'file '.$type.'.stub is not exist !';
+            echo 'file ' . $type . '.stub is not exist !';
 
             return false;
         }
@@ -217,7 +216,6 @@ class Generator extends Command
 
         $folder = str_replace('\\', '/', $folder);
         $path = str_replace('\\', '/', $path);
-
         $this->type($type, $folder, $path, $template);
 
         return true;
@@ -232,7 +230,7 @@ class Generator extends Command
      */
     public function getFolderOrCreate($path)
     {
-        if (! file_exists($path)) {
+        if (!file_exists($path)) {
             mkdir($path, 0777, true);
         }
 
@@ -240,9 +238,9 @@ class Generator extends Command
     }
 
     /**
-     * @param string $path     Class path
-     * @param string $folder   default path to generate in
-     * @param string $type     define which kind of files should generate
+     * @param string $path Class path
+     * @param string $folder default path to generate in
+     * @param string $type define which kind of files should generate
      * @param string $template temple file
      *
      * return void
@@ -251,7 +249,7 @@ class Generator extends Command
     {
         switch ($type) {
             case 'Entity':
-                $filePath = $this->getFolderOrCreate(Config::get('repository.app_path')."/{$folder}/{$path}");
+                $filePath = $this->getFolderOrCreate(Config::get('repository.app_path') . "/{$folder}/{$path}");
                 $filePath = rtrim($filePath, '/');
                 $content = "{$filePath}/{$this->repoName}.php";
 
@@ -260,7 +258,7 @@ class Generator extends Command
             case 'Request':
             case 'Repository':
             case 'Interface':
-                $filePath = $this->getFolderOrCreate(Config::get('repository.app_path')."/{$folder}/{$path}");
+                $filePath = $this->getFolderOrCreate(Config::get('repository.app_path') . "/{$folder}/{$path}");
                 $filePath = rtrim($filePath, '/');
                 $content = "{$filePath}/{$this->repoName}{$type}.php";
                 break;
@@ -268,14 +266,14 @@ class Generator extends Command
             case 'edit':
             case 'index':
             case 'show':
-                $filePath = $this->getFolderOrCreate($folder.'/'.Str::plural($path)).'/';
+                $filePath = $this->getFolderOrCreate($folder . '/' . Str::plural($path)) . '/';
                 $repoName = lcfirst($type);
-                $content = $filePath.$repoName.'.blade.php';
+                $content = $filePath . $repoName . '.blade.php';
                 break;
             default:
-                $filePath = $this->getFolderOrCreate($folder).'/';
+                $filePath = $this->getFolderOrCreate($folder) . '/';
                 $repoName = lcfirst($this->repoName);
-                $content = $filePath.$repoName.'.php';
+                $content = $filePath . $repoName . '.php';
         }
 
         if(is_dir($filePath) && file_exists($content)){
@@ -286,4 +284,10 @@ class Generator extends Command
 
         file_put_contents($content, $template);
     }
+
+    function dumpAutoload()
+    {
+        shell_exec('composer dump-autoload');
+    }
 }
+

--- a/src/Utility/Controller.php
+++ b/src/Utility/Controller.php
@@ -132,6 +132,7 @@ class Controller extends \App\Http\Controllers\Controller
     public function index()
     {
         $data = $this->interface->simplePaginate($this->limit, $this->request->all());
+
         if (! $this->isAPI) {
             View::share('pageTitle', 'List '.$this->pageTitle.' | '.Config::get('app.name'));
             $this->breadcrumbs->put('index', [

--- a/stubs/Controller.stub
+++ b/stubs/Controller.stub
@@ -13,7 +13,7 @@ use Shamaseen\Repository\Generator\Utility\Controller;
 class {{modelName}}Controller extends Controller
 {
 
-    protected $routeIndex = '{{lcPluralModelName}}.index';
+    protected $routeIndex = '{{lcPluralModelName}}/index';
 
     protected $pageTitle = '{{modelName}}';
     protected $createRoute = '{{lcPluralModelName}}.create';

--- a/stubs/Controller.stub
+++ b/stubs/Controller.stub
@@ -13,7 +13,7 @@ use Shamaseen\Repository\Generator\Utility\Controller;
 class {{modelName}}Controller extends Controller
 {
 
-    protected $routeIndex = '{{lcPluralModelName}}/index';
+    protected $routeIndex = '{{lcPluralModelName}}.index';
 
     protected $pageTitle = '{{modelName}}';
     protected $createRoute = '{{lcPluralModelName}}.create';


### PR DESCRIPTION
This PR fixes the issues of a file been replaced by reruning the make repository command.

On this PR, when the migrate repository command is rerun, it checks to see if a file exists, if the file exists, it does not replace it, rather it shows an output on the terminal that the file exists and also does not repeatedly append the repository's route resources link on the` web.php `file